### PR TITLE
Add Rust HTTP constants

### DIFF
--- a/contents/codes/520.md
+++ b/contents/codes/520.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 520
+title: 520 Web Server Returned an Unknown Error
+---
+
+The origin server returned an empty, unknown, or unexplained response to Cloudflare.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#520error>

--- a/contents/codes/521.md
+++ b/contents/codes/521.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 521
+title: Web Server Is Down
+---
+
+This status code is not specified in any RFCs, but is used by CloudFlare's reverse proxies to indicate that the origin webserver refused the connection.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#521error>

--- a/contents/codes/522.md
+++ b/contents/codes/522.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 522
+title: Connection Timed Out
+---
+
+Cloudflare could not negotiate a TCP handshake with the origin server.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#522error>

--- a/contents/codes/523.md
+++ b/contents/codes/523.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 523
+title: Origin Is Unreachable
+---
+
+Cloudflare could not reach the origin server; for example, if the DNS records for the origin server are incorrect.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#523error>

--- a/contents/codes/524.md
+++ b/contents/codes/524.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 524
+title: Origin Is Unreachable
+---
+
+Cloudflare was able to complete a TCP connection to the origin server, but did not receive a timely HTTP response.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#524error>

--- a/contents/codes/525.md
+++ b/contents/codes/525.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 525
+title: Origin Is Unreachable
+---
+
+Cloudflare could not negotiate a SSL/TLS handshake with the origin server.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#525error>

--- a/contents/codes/526.md
+++ b/contents/codes/526.md
@@ -1,0 +1,15 @@
+---
+# This is not a status code available in the standard, but it exists
+# with significant prominence in the wild
+set: 5
+code: 526
+title: Origin Is Unreachable
+---
+
+Cloudflare could not validate the SSL certificate on the origin web server.[1]
+
+---
+
+* Source: [unknown?][1]
+
+[1]: <https://support.cloudflare.com/hc/en-us/articles/115003011431#526error>


### PR DESCRIPTION
In case I need to do this again.

I created a file of status code to constant names, then ran this script
against it:

IFS=$'\n';
for i in $(cat rust-consts.txt); do
  code="$(echo $i | awk '{print $1}')"
  const="http::StatusCode::$(echo $i | awk '{print $2}')"
  fastmod "(references:)(\n)" "\${1}\${2}    \"Rust HTTP Status Constant\": \"${const}\"\${2}" "contents/codes/${code}.md"
done

The hightlight is the grossness for the fastmod invocation, since I
couldn't figure out how to get fastmod to add newlines in the
replacement text, so I captured and reused the one from the searched
patterns.