### PR TITLE
add some cloudflare statuses

### DIFF
--- a/contents/codes/100.md
+++ b/contents/codes/100.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.CONTINUE"
     "Python3+ HTTP Status Constant": "http.client.CONTINUE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.CONTINUE"
+    "C# HTTP Status Enum": "HttpStatusCode.Continue"
 ---
 
 The initial part of a request has been received and has not yet been rejected by the server. The server intends to send a final response after the request has been fully received and acted upon.

--- a/contents/codes/101.md
+++ b/contents/codes/101.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.SWITCHING_PROTOCOLS"
     "Python3+ HTTP Status Constant": "http.client.SWITCHING_PROTOCOLS"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.SWITCHING_PROTOCOLS"
+    "C# HTTP Status Enum": "HttpStatusCode.SwitchingProtocols"
 ---
 
 The server understands and is willing to comply with the client's request, via the Upgrade header field<sup>[1](#ref-1)</sup>, for a change in the application protocol being used on this connection.

--- a/contents/codes/102.md
+++ b/contents/codes/102.md
@@ -5,6 +5,7 @@ title: Processing
 references:
     "Rails HTTP Status Symbol": ":processing"
     "Symfony HTTP Status Constant": "Response::HTTP_PROCESSING"
+    "C# HTTP Status Enum": "HttpStatusCode.Processing"
 ---
 
 An interim response used to inform the client that the server has accepted the complete request, but has not yet completed it.

--- a/contents/codes/200.md
+++ b/contents/codes/200.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.OK"
     "Python3+ HTTP Status Constant": "http.client.OK"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.OK"
+    "C# HTTP Status Enum": "HttpStatusCode.OK"
 ---
 
 The request has succeeded.

--- a/contents/codes/201.md
+++ b/contents/codes/201.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.CREATED"
     "Python3+ HTTP Status Constant": "http.client.CREATED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.CREATED"
+    "C# HTTP Status Enum": "HttpStatusCode.Created"
 ---
 
 The request has been fulfilled and has resulted in one or more new resources being created.

--- a/contents/codes/202.md
+++ b/contents/codes/202.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.ACCEPTED"
     "Python3+ HTTP Status Constant": "http.client.ACCEPTED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.ACCEPTED"
+    "C# HTTP Status Enum": "HttpStatusCode.Accepted"
 ---
 
 The request has been accepted for processing, but the processing has not been

--- a/contents/codes/203.md
+++ b/contents/codes/203.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.NON_AUTHORITATIVE_INFORMATION"
     "Python3+ HTTP Status Constant": "http.client.NON_AUTHORITATIVE_INFORMATION"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NON_AUTHORITATIVE_INFORMATION"
+    "C# HTTP Status Enum": "HttpStatusCode.NonAuthoritativeInformation"
 ---
 
 The request was successful but the enclosed payload has been modified from that of the origin server's [200 OK](/200) response by a transforming proxy<sup>[1](#ref-1)</sup>.

--- a/contents/codes/204.md
+++ b/contents/codes/204.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.NO_CONTENT"
     "Python3+ HTTP Status Constant": "http.client.NO_CONTENT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NO_CONTENT"
+    "C# HTTP Status Enum": "HttpStatusCode.NoContent"
 ---
 
 The server has successfully fulfilled the request and that there is no additional content to send in the response payload body.

--- a/contents/codes/205.md
+++ b/contents/codes/205.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.RESET_CONTENT"
     "Python3+ HTTP Status Constant": "http.client.RESET_CONTENT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.RESET_CONTENT"
+    "C# HTTP Status Enum": "HttpStatusCode.ResetContent"
 ---
 
 The server has fulfilled the request and desires that the user agent reset the "document view", which caused the request to be sent, to its original state as received from the origin server.

--- a/contents/codes/206.md
+++ b/contents/codes/206.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.PARTIAL_CONTENT"
     "Python3+ HTTP Status Constant": "http.client.PARTIAL_CONTENT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PARTIAL_CONTENT"
+    "C# HTTP Status Enum": "HttpStatusCode.PartialContent"
 ---
 
 The server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation that correspond to the satisfiable ranges found in the request's Range header field<sup>[1](#ref-1)</sup>.

--- a/contents/codes/207.md
+++ b/contents/codes/207.md
@@ -5,6 +5,7 @@ title: Multi-Status
 references:
     "Rails HTTP Status Symbol": ":multi_status"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTI_STATUS"
+    "C# HTTP Status Enum": "HttpStatusCode.MultiStatus"
 ---
 
 A Multi-Status response conveys information about multiple resources in situations where multiple status codes might be appropriate.

--- a/contents/codes/208.md
+++ b/contents/codes/208.md
@@ -4,6 +4,7 @@ code: 208
 title: Already Reported
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_ALREADY_REPORTED"
+    "C# HTTP Status Enum": "HttpStatusCode.AlreadyReported"
 ---
 
 Used inside a DAV: propstat response element to avoid enumerating the internal members of multiple bindings to the same collection repeatedly.

--- a/contents/codes/226.md
+++ b/contents/codes/226.md
@@ -5,6 +5,7 @@ title: IM Used
 references:
     "Rails HTTP Status Symbol": ":im_used"
     "Symfony HTTP Status Constant": "Response::HTTP_IM_USED"
+    "C# HTTP Status Enum": "HttpStatusCode.IMUsed"
 ---
 
 The server has fulfilled a GET request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance.

--- a/contents/codes/300.md
+++ b/contents/codes/300.md
@@ -9,6 +9,8 @@ references:
     "Python2 HTTP Status Constant": "httplib.MULTIPLE_CHOICES"
     "Python3+ HTTP Status Constant": "http.client.MULTIPLE_CHOICES"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.MULTIPLE_CHOICES"
+    "C# HTTP Status Enum": "HttpStatusCode.Ambiguous"
+    "C# HTTP Status Enum (Alternative)": "HttpStatusCode.MultipleChoices"
 ---
 
 The target resource has more than one representation, each with its own more specific identifier, and information about the alternatives is being provided so that the user (or user agent) can select a preferred representation by redirecting its request to one or more of those identifiers.

--- a/contents/codes/301.md
+++ b/contents/codes/301.md
@@ -9,6 +9,8 @@ references:
     "Python2 HTTP Status Constant": "httplib.MOVED_PERMANENTLY"
     "Python3+ HTTP Status Constant": "http.client.MOVED_PERMANENTLY"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.MOVED_PERMANENTLY"
+    "C# HTTP Status Enum": "HttpStatusCode.Moved"
+    "C# HTTP Status Enum (Alternative)": "HttpStatusCode.MovedPermanently"
 ---
 
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

--- a/contents/codes/302.md
+++ b/contents/codes/302.md
@@ -9,6 +9,8 @@ references:
     "Python2 HTTP Status Constant": "httplib.FOUND"
     "Python3+ HTTP Status Constant": "http.client.FOUND"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.FOUND"
+    "C# HTTP Status Enum": "HttpStatusCode.Found"
+    "C# HTTP Status Enum (Alternative)": "HttpStatusCode.Redirect"
 ---
 
 The target resource resides temporarily under a different URI. Since the redirection might be altered on occasion, the client ought to continue to use the effective request URI for future requests.

--- a/contents/codes/303.md
+++ b/contents/codes/303.md
@@ -9,6 +9,8 @@ references:
     "Python2 HTTP Status Constant": "httplib.SEE_OTHER"
     "Python3+ HTTP Status Constant": "http.client.SEE_OTHER"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.SEE_OTHER"
+    "C# HTTP Status Enum": "HttpStatusCode.RedirectMethod"
+    "C# HTTP Status Enum (Alternative)": "HttpStatusCode.SeeOther"
 ---
 
 The server is redirecting the user agent to a different resource, as indicated by a URI in the Location header field, which is intended to provide an indirect response to the original request.

--- a/contents/codes/304.md
+++ b/contents/codes/304.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.NOT_MODIFIED"
     "Python3+ HTTP Status Constant": "http.client.NOT_MODIFIED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_MODIFIED"
+    "C# HTTP Status Enum": "HttpStatusCode.NotModified"
 ---
 
 A conditional GET or HEAD request has been received and would have resulted in a [200 OK](/200) response if it were not for the fact that the condition evaluated to false.

--- a/contents/codes/305.md
+++ b/contents/codes/305.md
@@ -9,6 +9,7 @@ title: Use Proxy
 #   "Python2 HTTP Status Constant": "httplib.USE_PROXY"
 #   "Python3+ HTTP Status Constant": "http.client.USE_PROXY"
 #   "Python3.5+ HTTP Status Constant": "http.HTTPStatus.USE_PROXY"
+#   "C# HTTP Status Enum": "HttpStatusCode.UseProxy"
 #   - Due to deprecation we won't show this... but should we?
 ---
 

--- a/contents/codes/307.md
+++ b/contents/codes/307.md
@@ -9,6 +9,8 @@ references:
     "Python2 HTTP Status Constant": "httplib.TEMPORARY_REDIRECT"
     "Python3+ HTTP Status Constant": "http.client.TEMPORARY_REDIRECT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.TEMPORARY_REDIRECT"
+    "C# HTTP Status Enum": "HttpStatusCode.RedirectKeepVerb"
+    "C# HTTP Status Enum (Alternative)": "HttpStatusCode.TemporaryRedirect"
 ---
 
 The target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.

--- a/contents/codes/308.md
+++ b/contents/codes/308.md
@@ -4,6 +4,7 @@ code: 308
 title: Permanent Redirect
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_PERMANENTLY_REDIRECT"
+    "C# HTTP Status Enum": "HttpStatusCode.PermanentRedirect"
 ---
 
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

--- a/contents/codes/400.md
+++ b/contents/codes/400.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.BAD_REQUEST"
     "Python3+ HTTP Status Constant": "http.client.BAD_REQUEST"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.BAD_REQUEST"
+    "C# HTTP Status Enum": "HttpStatusCode.BadRequest"
 ---
 
 The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).

--- a/contents/codes/401.md
+++ b/contents/codes/401.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.UNAUTHORIZED"
     "Python3+ HTTP Status Constant": "http.client.UNAUTHORIZED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.UNAUTHORIZED"
+    "C# HTTP Status Enum": "HttpStatusCode.Unauthorized"
 ---
 
 The request has not been applied because it lacks valid authentication credentials for the target resource.

--- a/contents/codes/402.md
+++ b/contents/codes/402.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.PAYMENT_REQUIRED"
     "Python3+ HTTP Status Constant": "http.client.PAYMENT_REQUIRED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PAYMENT_REQUIRED"
+    "C# HTTP Status Enum": "HttpStatusCode.PaymentRequired"
 ---
 
 Reserved for future use.

--- a/contents/codes/403.md
+++ b/contents/codes/403.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.FORBIDDEN"
     "Python3+ HTTP Status Constant": "http.client.FORBIDDEN"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.FORBIDDEN"
+    "C# HTTP Status Enum": "HttpStatusCode.Forbidden"
 ---
 
 The server understood the request but refuses to authorize it.

--- a/contents/codes/404.md
+++ b/contents/codes/404.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.NOT_FOUND"
     "Python3+ HTTP Status Constant": "http.client.NOT_FOUND"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_FOUND"
+    "C# HTTP Status Enum": "HttpStatusCode.NotFound"
 ---
 
 The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.

--- a/contents/codes/405.md
+++ b/contents/codes/405.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.METHOD_NOT_ALLOWED"
     "Python3+ HTTP Status Constant": "http.client.METHOD_NOT_ALLOWED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.METHOD_NOT_ALLOWED"
+    "C# HTTP Status Enum": "HttpStatusCode.MethodNotAllowed"
 ---
 
 The method received in the request-line is known by the origin server but not supported by the target resource.

--- a/contents/codes/406.md
+++ b/contents/codes/406.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.NOT_ACCEPTABLE"
     "Python3+ HTTP Status Constant": "http.client.NOT_ACCEPTABLE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_ACCEPTABLE"
+    "C# HTTP Status Enum": "HttpStatusCode.NotAcceptable"
 ---
 
 The target resource does not have a current representation that would be acceptable to the user agent, according to the proactive negotiation header fields received in the request<sup>[1](#ref-1)</sup>, and the server is unwilling to supply a default representation.

--- a/contents/codes/407.md
+++ b/contents/codes/407.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.PROXY_AUTHENTICATION_REQUIRED"
     "Python3+ HTTP Status Constant": "http.client.PROXY_AUTHENTICATION_REQUIRED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PROXY_AUTHENTICATION_REQUIRED"
+    "C# HTTP Status Enum": "HttpStatusCode.ProxyAuthenticationRequired"
 ---
 
 Similar to [401 Unauthorized](/401), but it indicates that the client needs to authenticate itself in order to use a proxy.

--- a/contents/codes/408.md
+++ b/contents/codes/408.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.REQUEST_TIMEOUT"
     "Python3+ HTTP Status Constant": "http.client.REQUEST_TIMEOUT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUEST_TIMEOUT"
+    "C# HTTP Status Enum": "HttpStatusCode.RequestTimeout"
 ---
 
 The server did not receive a complete request message within the time that it was prepared to wait.

--- a/contents/codes/409.md
+++ b/contents/codes/409.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.CONFLICT"
     "Python3+ HTTP Status Constant": "http.client.CONFLICT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.CONFLICT"
+    "C# HTTP Status Enum": "HttpStatusCode.Conflict"
 ---
 
 The request could not be completed due to a conflict with the current state of the target resource. This code is used in situations where the user might be able to resolve the conflict and resubmit the request.

--- a/contents/codes/410.md
+++ b/contents/codes/410.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.GONE"
     "Python3+ HTTP Status Constant": "http.client.GONE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.GONE"
+    "C# HTTP Status Enum": "HttpStatusCode.Gone"
 ---
 
 The target resource is no longer available at the origin server and that this condition is likely to be permanent.

--- a/contents/codes/411.md
+++ b/contents/codes/411.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.LENGTH_REQUIRED"
     "Python3+ HTTP Status Constant": "http.client.LENGTH_REQUIRED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.LENGTH_REQUIRED"
+    "C# HTTP Status Enum": "HttpStatusCode.LengthRequired"
 ---
 
 The server refuses to accept the request without a defined Content-Length<sup>[1](#ref-1)</sup>.

--- a/contents/codes/412.md
+++ b/contents/codes/412.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.PRECONDITION_FAILED"
     "Python3+ HTTP Status Constant": "http.client.PRECONDITION_FAILED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.PRECONDITION_FAILED"
+    "C# HTTP Status Enum": "HttpStatusCode.PreconditionFailed"
 ---
 
 One or more conditions given in the request header fields evaluated to false when tested on the server.

--- a/contents/codes/413.md
+++ b/contents/codes/413.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.REQUEST_ENTITY_TOO_LARGE"
     "Python3+ HTTP Status Constant": "http.client.REQUEST_ENTITY_TOO_LARGE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUEST_ENTITY_TOO_LARGE"
+    "C# HTTP Status Enum": "HttpStatusCode.RequestEntityTooLarge"
 ---
 
 The server is refusing to process a request because the request payload is larger than the server is willing or able to process.

--- a/contents/codes/414.md
+++ b/contents/codes/414.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.REQUEST_URI_TOO_LONG"
     "Python3+ HTTP Status Constant": "http.client.REQUEST_URI_TOO_LONG"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUEST_URI_TOO_LONG"
+    "C# HTTP Status Enum": "HttpStatusCode.RequestUriTooLong"
 ---
 
 The server is refusing to service the request because the request-target<sup>[1](#ref-1)</sup> is longer than the server is willing to interpret.

--- a/contents/codes/415.md
+++ b/contents/codes/415.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.UNSUPPORTED_MEDIA_TYPE"
     "Python3+ HTTP Status Constant": "http.client.UNSUPPORTED_MEDIA_TYPE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.UNSUPPORTED_MEDIA_TYPE"
+    "C# HTTP Status Enum": "HttpStatusCode.UnsupportedMediaType"
 ---
 
 The origin server is refusing to service the request because the payload is in a format not supported by this method on the target resource.

--- a/contents/codes/416.md
+++ b/contents/codes/416.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.REQUESTED_RANGE_NOT_SATISFIABLE"
     "Python3+ HTTP Status Constant": "http.client.REQUESTED_RANGE_NOT_SATISFIABLE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE"
+    "C# HTTP Status Enum": "HttpStatusCode.RequestedRangeNotSatisfiable"
 ---
 
 None of the ranges in the request's Range header field<sup>[1](#ref-1)</sup> overlap the current extent of the selected resource or that the set of ranges requested has been rejected due to invalid ranges or an excessive request of small or overlapping ranges.

--- a/contents/codes/417.md
+++ b/contents/codes/417.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.EXPECTATION_FAILED"
     "Python3+ HTTP Status Constant": "http.client.EXPECTATION_FAILED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.EXPECTATION_FAILED"
+    "C# HTTP Status Enum": "HttpStatusCode.ExpectationFailed"
 ---
 
 The expectation given in the request's Expect header field<sup>[1](#ref-1)</sup> could not be met by at least one of the inbound servers.

--- a/contents/codes/421.md
+++ b/contents/codes/421.md
@@ -4,6 +4,7 @@ code: 421
 title: Misdirected Request
 references:
     "Rails HTTP Status Symbol": ":misdirected_request"
+    "C# HTTP Status Enum": "HttpStatusCode.MisdirectedRequest"
 ---
 
 The request was directed at a server that is not able to produce a response. This can be sent by a server that is not configured to produce responses for the combination of scheme and authority that are included in the request URI.

--- a/contents/codes/422.md
+++ b/contents/codes/422.md
@@ -5,6 +5,7 @@ title: Unprocessable Entity
 references:
     "Rails HTTP Status Symbol": ":unprocessable_entity"
     "Symfony HTTP Status Constant": "Response::HTTP_UNPROCESSABLE_ENTITY"
+    "C# HTTP Status Enum": "HttpStatusCode.UnprocessableEntity"
 ---
 
 The server understands the content type of the request entity (hence a [415 Unsupported Media Type](/415) status code is inappropriate), and the syntax of the request entity is correct (thus a [400 Bad Request](/400) status code is inappropriate) but was unable to process the contained instructions.

--- a/contents/codes/423.md
+++ b/contents/codes/423.md
@@ -5,6 +5,7 @@ title: Locked
 references:
     "Rails HTTP Status Symbol": ":locked"
     "Symfony HTTP Status Constant": "Response::HTTP_LOCKED"
+    "C# HTTP Status Enum": "HttpStatusCode.Locked"
 ---
 
 The source or destination resource of a method is locked.

--- a/contents/codes/424.md
+++ b/contents/codes/424.md
@@ -6,6 +6,7 @@ references:
     "Rails HTTP Status Symbol": "failed_dependency"
     "Symfony HTTP Status Constant": "Response::HTTP_FAILED_DEPENDENCY"
     "Python HTTP Status Constant": "httplib.FAILED_DEPENDENCY"
+    "C# HTTP Status Enum": "HttpStatusCode.FailedDependency"
 ---
 
 The method could not be performed on the resource because the requested action depended on another action and that action failed.

--- a/contents/codes/426.md
+++ b/contents/codes/426.md
@@ -5,6 +5,7 @@ title: Upgrade Required
 references:
     "Rails HTTP Status Symbol": ":upgrade_required"
     "Symfony HTTP Status Constant": "Response::HTTP_UPGRADE_REQUIRED"
+    "C# HTTP Status Enum": "HttpStatusCode.UpgradeRequired"
 ---
 
 The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.

--- a/contents/codes/428.md
+++ b/contents/codes/428.md
@@ -4,6 +4,7 @@ code: 428
 title: Precondition Required
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_REQUIRED"
+    "C# HTTP Status Enum": "HttpStatusCode.PreconditionRequired"
 ---
 
 The origin server requires the request to be conditional.

--- a/contents/codes/429.md
+++ b/contents/codes/429.md
@@ -4,6 +4,7 @@ code: 429
 title: Too Many Requests
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_TOO_MANY_REQUESTS"
+    "C# HTTP Status Enum": "HttpStatusCode.TooManyRequests"
 ---
 
 The user has sent too many requests in a given amount of time ("rate limiting").

--- a/contents/codes/431.md
+++ b/contents/codes/431.md
@@ -4,6 +4,7 @@ code: 431
 title: Request Header Fields Too Large
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE"
+    "C# HTTP Status Enum": "HttpStatusCode.RequestHeaderFieldsTooLarge"
 ---
 
 The server is unwilling to process the request because its header fields are too large. The request MAY be resubmitted after reducing the size of the request header fields.

--- a/contents/codes/451.md
+++ b/contents/codes/451.md
@@ -5,6 +5,7 @@ title: Unavailable For Legal Reasons
 proposal: true
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_UNAVAILABLE_FOR_LEGAL_REASONS"
+    "C# HTTP Status Enum": "HttpStatusCode.UnavailableForLegalReasons"
 ---
 
 The server is denying access to the resource as a consequence of a legal demand.

--- a/contents/codes/500.md
+++ b/contents/codes/500.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.INTERNAL_SERVER_ERROR"
     "Python3+ HTTP Status Constant": "http.client.INTERNAL_SERVER_ERROR"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.INTERNAL_SERVER_ERROR"
+    "C# HTTP Status Enum": "HttpStatusCode.InternalServerError"
 ---
 
 The server encountered an unexpected condition that prevented it from fulfilling the request.

--- a/contents/codes/501.md
+++ b/contents/codes/501.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.NOT_IMPLEMENTED"
     "Python3+ HTTP Status Constant": "http.client.NOT_IMPLEMENTED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.NOT_IMPLEMENTED"
+    "C# HTTP Status Enum": "HttpStatusCode.NotImplemented"
 ---
 
 The server does not support the functionality required to fulfill the request.

--- a/contents/codes/502.md
+++ b/contents/codes/502.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.BAD_GATEWAY"
     "Python3+ HTTP Status Constant": "http.client.BAD_GATEWAY"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.BAD_GATEWAY"
+    "C# HTTP Status Enum": "HttpStatusCode.BadGateway"
 ---
 
 The server, while acting as a gateway or proxy, received an invalid response from an inbound server it accessed while attempting to fulfill the request.

--- a/contents/codes/503.md
+++ b/contents/codes/503.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.SERVICE_UNAVAILABLE"
     "Python3+ HTTP Status Constant": "http.client.SERVICE_UNAVAILABLE"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.SERVICE_UNAVAILABLE"
+    "C# HTTP Status Enum": "HttpStatusCode.ServiceUnavailable"
 ---
 
 The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.

--- a/contents/codes/504.md
+++ b/contents/codes/504.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.GATEWAY_TIMEOUT"
     "Python3+ HTTP Status Constant": "http.client.GATEWAY_TIMEOUT"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.GATEWAY_TIMEOUT"
+    "C# HTTP Status Enum": "HttpStatusCode.GatewayTimeout"
 ---
 
 The server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request.

--- a/contents/codes/505.md
+++ b/contents/codes/505.md
@@ -9,6 +9,7 @@ references:
     "Python2 HTTP Status Constant": "httplib.VERSION_NOT_SUPPORTED"
     "Python3+ HTTP Status Constant": "http.client.VERSION_NOT_SUPPORTED"
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.VERSION_NOT_SUPPORTED"
+    "C# HTTP Status Enum": "HttpStatusCode.HttpVersionNotSupported"
 ---
 
 The server does not support, or refuses to support, the major version of HTTP that was used in the request message.

--- a/contents/codes/506.md
+++ b/contents/codes/506.md
@@ -4,6 +4,7 @@ code: 506
 title: Variant Also Negotiates
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL"
+    "C# HTTP Status Enum": "HttpStatusCode.VariantAlsoNegotiates"
 ---
 
 The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process.

--- a/contents/codes/507.md
+++ b/contents/codes/507.md
@@ -5,6 +5,7 @@ title: Insufficient Storage
 references:
     "Rails HTTP Status Symbol": ":insufficient_storage"
     "Symfony HTTP Status Constant": "Response::HTTP_INSUFFICIENT_STORAGE"
+    "C# HTTP Status Enum": "HttpStatusCode.InsufficientStorage"
 ---
 
 The method could not be performed on the resource because the server is unable to store the representation needed to successfully complete the request.

--- a/contents/codes/508.md
+++ b/contents/codes/508.md
@@ -4,6 +4,7 @@ code: 508
 title: Loop Detected
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_LOOP_DETECTED"
+    "C# HTTP Status Enum": "HttpStatusCode.LoopDetected"
 ---
 
 The server terminated an operation because it encountered an infinite loop while processing a request with "Depth: infinity". This status indicates that the entire operation failed.

--- a/contents/codes/510.md
+++ b/contents/codes/510.md
@@ -5,6 +5,7 @@ title: Not Extended
 references:
     "Rails HTTP Status Symbol": ":not_extended"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_EXTENDED"
+    "C# HTTP Status Enum": "HttpStatusCode.NotExtended"
 ---
 
 The policy for accessing the resource has not been met in the request. The server should send back all the information necessary for the client to issue an extended request.

--- a/contents/codes/511.md
+++ b/contents/codes/511.md
@@ -4,6 +4,7 @@ code: 511
 title: Network Authentication Required
 references:
     "Symfony HTTP Status Constant": "Response::HTTP_NETWORK_AUTHENTICATION_REQUIRED"
+    "C# HTTP Status Enum": "HttpStatusCode.NetworkAuthenticationRequired"
 ---
 
 The client needs to authenticate to gain network access.


### PR DESCRIPTION
In case I need to do this again.

I created a file of status code to constant names, then ran this script
against it:

IFS=$'\n';
for i in $(cat rust-consts.txt); do
  code="$(echo $i | awk '{print $1}')"
  const="http::StatusCode::$(echo $i | awk '{print $2}')"
  fastmod "(references:)(\n)" "\${1}\${2}    \"Rust HTTP Status Constant\": \"${const}\"\${2}" "contents/codes/${code}.md"
done

The hightlight is the grossness for the fastmod invocation, since I
couldn't figure out how to get fastmod to add newlines in the
replacement text, so I captured and reused the one from the searched
patterns.